### PR TITLE
roll back changes so that reth can build

### DIFF
--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -240,10 +240,6 @@ impl DelegatingInspector {
 
                 Ok(DelegatingInspector::Prestate(prestate_config, inspector))
             }
-            GethDebugBuiltInTracerType::FlatCallTracer => {
-                // TODO support flat call tracer in mux
-                return Err(Error::UnexpectedConfig(tracer_type));
-            }
             GethDebugBuiltInTracerType::NoopTracer => {
                 if tracer_config.is_some() {
                     return Err(Error::UnexpectedConfig(tracer_type));


### PR DESCRIPTION
revm-inspectors version 0.6.0 cannot be built independently because its dependency alloy-rpc-types-trace-0.3.6 has an extra type FlatCallTracer defined in enum GethDebugBuiltInTracerType

```
cargo build
   Compiling revm-inspectors v0.6.0 (/Users/phe/Downloads/revm-inspectors-0.6.0)
error[E0004]: non-exhaustive patterns: `GethDebugBuiltInTracerType::FlatCallTracer` not covered
   --> src/tracing/mux.rs:214:31
    |
214 |         let inspector = match tracer_type {
    |                               ^^^^^^^^^^^ pattern `GethDebugBuiltInTracerType::FlatCallTracer` not covered
    |
note: `GethDebugBuiltInTracerType` defined here
   --> /Users/phe/.cargo/registry/src/index.crates.io-6f17d22bba15001f/alloy-rpc-types-trace-0.3.6/src/geth/mod.rs:255:1
    |
255 | pub enum GethDebugBuiltInTracerType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
270 |     FlatCallTracer,
    |     -------------- not covered
    = note: the matched value is of type `GethDebugBuiltInTracerType`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
255 ~             },
256 +             GethDebugBuiltInTracerType::FlatCallTracer => todo!()
    |

For more information about this error, try `rustc --explain E0004`.
error: could not compile `revm-inspectors` (lib) due to 1 previous error

``` 