### PR TITLE
chore: re-enable js-tracer feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ alloy-tx-macros = { version = "=1.1.0", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
+# js-tracer
+boa_engine = { version = "0.20", optional = true }
+boa_gc = { version = "0.20", optional = true }
+
 [dev-dependencies]
 snapbox = { version = "0.6", features = ["term-svg"] }
 
@@ -68,9 +72,9 @@ std = [
     "thiserror/std",
 ]
 serde = ["dep:serde", "revm/serde"]
-# Seismic Note: we keep the js-tracer feature because of transitive dependency hell (we didn't fork alloy), but completely disable it since
-# it gives caller-supplied JavaScript arbitrary live access to stack, memory, and storage during execution, which is incompatible with Seismic's privacy model.
-js-tracer = []
+# Seismic Note: we keep the js-tracer feature for foundry, but make sure to not enable this in reth, since it gives caller-supplied JavaScript
+# arbitrary live access to stack, memory, and storage during execution, which is incompatible with Seismic's privacy model.
+js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }

--- a/README.md
+++ b/README.md
@@ -57,13 +57,11 @@ Private slots are omitted entirely (not zeroed out) to avoid leaking access patt
 The trace output types (`PreStateFrame`, `StateDiff`, etc.) come from `alloy-rpc-types-trace` which we don't fork — they use `B256` for storage values, so the `is_private` flag from `FlaggedStorage` is lost after the builders convert storage to output format.
 Storage filtering must happen in the builders where `FlaggedStorage` is still available.
 
-### JS tracer disabled
+### JS tracer dangerous
 
-The upstream `js-tracer` feature allows callers to supply arbitrary JavaScript that runs *during* EVM execution with live access to `log.stack.peek()`, `log.memory.slice()`, and `db.getState()`. This hands private data to untrusted code in real time — no post-processing sanitizer can help.
+The `js-tracer` feature allows callers to supply arbitrary JavaScript that runs *during* EVM execution with live access to `log.stack.peek()`, `log.memory.slice()`, and `db.getState()`. This hands private data to untrusted code in real time — no post-processing sanitizer can help.
 
-Re-enabling this safely would require making revm's stack use `FlaggedStorage` (taint tracking), so the JS tracer's stack/memory/storage APIs could filter private values before handing them to user code. That's a large engineering lift (every opcode handler needs taint propagation) and not planned currently.
-
-The feature flag is kept in `Cargo.toml` (to avoid breaking transitive dependency chains in seismic-reth) but maps to an empty feature set — enabling it is a no-op. The JS tracer module is commented out and the source files are not compiled.
+We keep this feature in case it is useful for foundry users to debug, but note that this should never be enabled on reth. Making this work safely would require making revm's stack use `FlaggedStorage` (taint tracking), so the JS tracer's stack/memory/storage APIs could filter private values before handing them to user code. That's a large engineering lift (every opcode handler needs taint propagation) and not planned currently.
 
 ### ERC-7562 tracer not available
 

--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -984,7 +984,11 @@ where
         self.0.code_by_hash_ref(_code_hash).map_err(|e| e.to_string().into())
     }
 
-    fn storage_ref(&self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+    fn storage_ref(
+        &self,
+        _address: Address,
+        _index: U256,
+    ) -> Result<alloy_primitives::FlaggedStorage, Self::Error> {
         self.0.storage_ref(_address, _index).map_err(|e| e.to_string().into())
     }
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -55,12 +55,8 @@ pub use writer::{TraceWriter, TraceWriterConfig};
 
 pub mod trace_sanitizer;
 
-// JS tracer removed: it gives caller-supplied JavaScript arbitrary live access to
-// stack, memory, and storage during execution, which is incompatible with Seismic's
-// privacy model. We could reenable this in the future if we make revm's stack hold FlaggedStorage
-// and do full filtering of the JS output, but that's a pretty big lift.
-// #[cfg(feature = "js-tracer")]
-// pub mod js;
+#[cfg(feature = "js-tracer")]
+pub mod js;
 
 mod mux;
 pub use mux::{Error as MuxError, MuxInspector};


### PR DESCRIPTION
Re-enabling since I figured we might want to use this in foundry, and without this we would have had to delete all spots in foundry that used js-tracer as a #[cfg] block, making our upstream fork even larger.