### PR TITLE
fix: sanitize otterscan traces and decoded revert reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Seismic's fork of [revm-inspectors](https://github.com/paradigmxyz/revm-inspecto
 | ----------------------------------------- | ------------ | --------------- | ----------------------------------- |
 | Call graph (from, to, value, gas, type)   | kept         | kept            | —                                   |
 | Execution flow (pc, opcode, gas per step) | kept         | kept            | —                                   |
-| Errors / reverts                          | kept         | kept            | —                                   |
+| Errors (generic VM failure strings)       | kept         | kept            | —                                   |
 | Logs / events                             | kept         | kept            | —                                   |
 | Account balances / nonces / code          | kept         | kept            | —                                   |
 | Public storage slots                      | kept         | kept            | —                                   |
 | **Private storage slots**                 | **omitted**  | kept            | builders (`filter_private_storage`) |
 | **Calldata (all frames)**                 | **stripped** | kept            | sanitizer                           |
 | **Return data (all frames)**              | **stripped** | kept            | sanitizer                           |
+| **Revert payloads / decoded reasons**     | **stripped** | kept            | sanitizer                           |
 | **Stack**                                 | **stripped** | kept            | sanitizer (defensive)               |
 | **Memory**                                | **stripped** | kept            | sanitizer (defensive)               |
 | **VM trace push/mem/store**               | **stripped** | kept            | sanitizer                           |
@@ -28,11 +29,14 @@ This fork threads `FlaggedStorage` through the tracing pipeline and provides **c
 
 ### Trace output sanitizer (`trace_sanitizer` module)
 
-This crate also provides a `trace_sanitizer` module with functions to strip private data from built trace output. 
+Why traces need wholesale stripping while `eth_call` does not: a signed-read `eth_call` exposes only the value the contract *chose* to return to `msg.sender` (encrypted to the signer) — the contract's own code is the access-control gate, so authenticating the caller is enough. A trace bypasses that gate, exposing raw internal execution (every frame's calldata/return data, intermediate values, inner revert payloads) including shielded state the tx merely *touched* but no contract chose to reveal. Authenticating the caller can't bound that, and filtering a trace down to what one party may see would require taint-tracking every value through the interpreter; so traces are stripped unconditionally instead.
+
+This crate provides a `trace_sanitizer` module with functions to strip private data from built trace output. 
 seismic-reth calls these from every debug/trace RPC handler before returning results to callers. 
 The sanitizer handles:
 - **Calldata**: stripped from all frames unconditionally (callers already know their own calldata; for regular txs it's available via `eth_getTransactionByHash`)
-- **Return data**: stripped from all frames
+- **Return data**: stripped from all frames, including revert payloads and decoded revert reasons (custom errors can embed shielded values); generic VM error strings are kept
+- **Otterscan trace entries** (`ots_traceTransaction`): calldata and return data stripped, call metadata kept
 - **Stack/memory**: defensively stripped (should already be disabled via `TracingInspectorConfig`, but stripped as a safety net)
 - **VM trace payloads**: push values, memory deltas, storage deltas stripped from `VmExecutedOperation`
 - **FourByteTracer**: stripped (function selectors reveal which function was called)
@@ -40,7 +44,7 @@ The sanitizer handles:
 - **Logs**: passed through (public by design)
 - **Gas/opcodes**: passed through
 
-All trace privacy logic lives in this crate so auditors can review it in one place. seismic-reth's responsibility is limited to calling `sanitize_geth_trace` / `sanitize_trace_results` / `sanitize_localized_transaction_trace` on every RPC handler return path.
+All trace privacy logic lives in this crate so auditors can review it in one place. seismic-reth's responsibility is limited to calling `sanitize_geth_trace` / `sanitize_trace_results` / `sanitize_localized_transaction_trace` / `sanitize_trace_entries` / `sanitize_revert_output` on every RPC handler return path — including the otterscan (`ots_*`) handlers.
 
 ### Storage filtering (configurable)
 

--- a/src/tracing/trace_sanitizer.rs
+++ b/src/tracing/trace_sanitizer.rs
@@ -6,14 +6,17 @@
 //!
 //! - Calldata: stripped from all frames (callers already know their own calldata; for regular txs
 //!   it's available via eth_getTransactionByHash)
-//! - Return data: stripped from all frames
+//! - Return data: stripped from all frames; this includes revert payloads and decoded revert
+//!   reasons, which are return data and can embed shielded values
 //! - VM trace payloads: push values, memory deltas, storage deltas stripped
 //! - Stack/memory: should already be disabled via TracingInspectorConfig
+//! - Otterscan trace entries (`ots_traceTransaction`): calldata and return data stripped
 
 use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use alloy_rpc_types_trace::{
     geth::{mux::MuxFrame, CallFrame, DefaultFrame, GethTrace, TraceResult},
+    otterscan::TraceEntry,
     parity::{
         Action, LocalizedTransactionTrace, TraceOutput, TraceResults,
         TraceResultsWithTransactionHash, TransactionTrace, VmInstruction, VmTrace,
@@ -76,6 +79,9 @@ fn sanitize_default_frame(mut frame: DefaultFrame) -> DefaultFrame {
 fn sanitize_call_frame(mut frame: CallFrame) -> CallFrame {
     frame.input = Bytes::new();
     frame.output = None;
+    // The decoded revert reason (Error(string)/Panic) is derived from the revert payload,
+    // i.e. return data. Keep `error` — that's the generic VM-level failure string.
+    frame.revert_reason = None;
 
     // Recursively sanitize nested calls.
     frame.calls = frame.calls.into_iter().map(sanitize_call_frame).collect();
@@ -150,6 +156,30 @@ pub fn sanitize_trace_results(mut results: TraceResults) -> TraceResults {
     // StateDiff: storage already filtered by builders. Nothing else to strip.
 
     results
+}
+
+/// Sanitizes otterscan [`TraceEntry`] frames (`ots_traceTransaction`) by stripping calldata
+/// and return data from every frame. Call metadata (type, depth, from, to, value) is kept,
+/// matching the parity sanitizer. Unlike parity, CREATE output is also stripped: deployed
+/// bytecode is public, but it's retrievable via eth_getCode and an unconditional strip is
+/// simpler to audit.
+pub fn sanitize_trace_entries(entries: Vec<TraceEntry>) -> Vec<TraceEntry> {
+    entries
+        .into_iter()
+        .map(|mut entry| {
+            entry.input = Bytes::new();
+            entry.output = Bytes::new();
+            entry
+        })
+        .collect()
+}
+
+/// Sanitizes a revert payload (`ots_getTransactionError`). Revert payloads are return data
+/// and can embed shielded values (e.g. a custom error carrying a private balance), so they
+/// are stripped like all other return data. That a transaction reverted is already public
+/// via its receipt status.
+pub fn sanitize_revert_output(_output: Bytes) -> Bytes {
+    Bytes::new()
 }
 
 /// Sanitizes [`TraceResultsWithTransactionHash`].

--- a/tests/it/sanitizer.rs
+++ b/tests/it/sanitizer.rs
@@ -8,6 +8,7 @@ use alloy_rpc_types_trace::{
     geth::{
         mux::MuxFrame, CallFrame, DefaultFrame, FourByteFrame, GethTrace, StructLog, TraceResult,
     },
+    otterscan::TraceEntry,
     parity::{
         Action, CallAction, CallOutput, CallType, CreateAction, CreationMethod,
         LocalizedTransactionTrace, StateDiff, TraceOutput, TraceResults,
@@ -16,8 +17,9 @@ use alloy_rpc_types_trace::{
     },
 };
 use revm_inspectors::tracing::trace_sanitizer::{
-    sanitize_geth_trace, sanitize_localized_transaction_trace, sanitize_trace_results,
-    sanitize_trace_results_vec, sanitize_trace_results_with_hash,
+    sanitize_geth_trace, sanitize_localized_transaction_trace, sanitize_revert_output,
+    sanitize_trace_entries, sanitize_trace_results, sanitize_trace_results_vec,
+    sanitize_trace_results_with_hash,
 };
 use std::collections::BTreeMap;
 
@@ -625,4 +627,86 @@ fn test_sanitize_vm_trace_nested_sub() {
     assert!(sub_ex.push.is_empty(), "nested push stripped");
     assert!(sub_ex.mem.is_none(), "nested mem stripped");
     assert_eq!(sub_ex.used, 50, "nested used preserved");
+}
+
+// ───────────────────────────── Geth: revert reason ────────────────────────────
+
+#[test]
+fn test_sanitize_call_frame_revert_reason() {
+    let frame = CallFrame {
+        input: Bytes::from(vec![0xde, 0xad]),
+        output: Some(Bytes::from(vec![0xca, 0xfe])),
+        error: Some("execution reverted".to_string()),
+        revert_reason: Some("InsufficientBalance(1337)".to_string()),
+        typ: "CALL".to_string(),
+        calls: vec![CallFrame {
+            error: Some("execution reverted".to_string()),
+            revert_reason: Some("secret reason".to_string()),
+            typ: "CALL".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let sanitized = sanitize_geth_trace(GethTrace::CallTracer(frame));
+    let GethTrace::CallTracer(f) = sanitized else { panic!("expected CallTracer") };
+
+    assert!(f.revert_reason.is_none(), "revert_reason is decoded return data, must be stripped");
+    assert_eq!(f.error.as_deref(), Some("execution reverted"), "generic error string preserved");
+    assert!(f.calls[0].revert_reason.is_none(), "nested revert_reason must be stripped");
+    assert_eq!(f.calls[0].error.as_deref(), Some("execution reverted"));
+}
+
+// ───────────────────────────── Otterscan: TraceEntry ──────────────────────────
+
+#[test]
+fn test_sanitize_trace_entries() {
+    let entries = vec![
+        TraceEntry {
+            r#type: "CALL".to_string(),
+            depth: 0,
+            from: address!("0x0000000000000000000000000000000000000001"),
+            to: address!("0x0000000000000000000000000000000000000002"),
+            value: Some(U256::from(42)),
+            input: Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+            output: Bytes::from(vec![0xca, 0xfe]),
+        },
+        // Nested frame, e.g. a shielded value passed between contracts or a
+        // precompile decrypt result.
+        TraceEntry {
+            r#type: "STATICCALL".to_string(),
+            depth: 1,
+            from: address!("0x0000000000000000000000000000000000000002"),
+            to: address!("0x0000000000000000000000000000000000000003"),
+            value: Some(U256::ZERO),
+            input: Bytes::from(vec![0x11, 0x22]),
+            output: Bytes::from(vec![0x33, 0x44]),
+        },
+    ];
+
+    let sanitized = sanitize_trace_entries(entries);
+
+    assert_eq!(sanitized.len(), 2);
+    for entry in &sanitized {
+        assert!(entry.input.is_empty(), "input must be stripped");
+        assert!(entry.output.is_empty(), "output must be stripped");
+    }
+
+    // Call metadata preserved
+    assert_eq!(sanitized[0].r#type, "CALL");
+    assert_eq!(sanitized[0].depth, 0);
+    assert_eq!(sanitized[0].from, address!("0x0000000000000000000000000000000000000001"));
+    assert_eq!(sanitized[0].to, address!("0x0000000000000000000000000000000000000002"));
+    assert_eq!(sanitized[0].value, Some(U256::from(42)));
+    assert_eq!(sanitized[1].r#type, "STATICCALL");
+    assert_eq!(sanitized[1].depth, 1);
+}
+
+// ───────────────────────────── Otterscan: revert output ───────────────────────
+
+#[test]
+fn test_sanitize_revert_output() {
+    let revert_payload = Bytes::from(vec![0x08, 0xc3, 0x79, 0xa0, 0x01, 0x02, 0x03]);
+    assert!(sanitize_revert_output(revert_payload).is_empty(), "revert payload must be stripped");
+    assert!(sanitize_revert_output(Bytes::new()).is_empty());
 }


### PR DESCRIPTION
Fixes veridise-1085 (along with reth-side PR).

The otterscan (ots_*) endpoints build trace output directly from the inspector arena instead of going through the geth/parity builders, so their output never passed through any trace_sanitizer function. Add the missing sanitizers:
- sanitize_trace_entries: strips input/output from every ots_traceTransaction frame, keeping call metadata (type, depth, from, to, value) to match the parity sanitizer.
- sanitize_revert_output: blanks the ots_getTransactionError revert payload. Revert bytes are return data and can embed shielded values; that a tx reverted is already public via its receipt status.

Also fix sanitize_call_frame, which stripped output but left revert_reason set. revert_reason is decoded from the same revert payload, so custom errors / require(_, msg) survived sanitization on debug_traceTransaction's callTracer. Clear it; keep the generic VM-level error string.

README documents why traces are stripped wholesale rather than gated by authentication: eth_call relies on the contract as the access-control gate, traces bypass it.